### PR TITLE
Fix wrong repo link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ Over-the-air update functionality is currently untested.
 
 ### Issues / Contributing
 
-Please raise any issues with this container at its GitHub repo: https://github.com/deconzcommunity/docker-deconz. Please check the "Gotchas / Known Issues" section above before raising an Issue on GitHub in case the issue is already known.
+Please raise any issues with this container at its GitHub repo: https://github.com/deconz-community/deconz-docker. Please check the "Gotchas / Known Issues" section above before raising an Issue on GitHub in case the issue is already known.
 
 To contribute, please fork the GitHub repo, create a feature branch, and raise a Pull Request; for simple changes/fixes, it may be more effective to raise an Issue instead.
 


### PR DESCRIPTION
Just one broken link I found while reading the doc on docker hub.