### PR TITLE
Clean up old VNC sessions and lock files

### DIFF
--- a/docker/root/start.sh
+++ b/docker/root/start.sh
@@ -94,6 +94,12 @@ if [ "$DECONZ_VNC_MODE" != 0 ]; then
 
   # Cleanup previous VNC session data
   gosu deconz tigervncserver -kill "$DECONZ_VNC_DISPLAY"
+  gosu deconz tigervncserver -list ':*' -cleanstale
+  for lock in "/tmp/.X${DECONZ_VNC_DISPLAY#:}-lock" "/tmp/.X11-unix/X${DECONZ_VNC_DISPLAY#:}"; do
+    [ -e "$lock" ] || continue
+    echo "[deconzcommunity/deconz] WARN - VNC-lock found. Deleting: $lock"
+    rm "$lock"
+  done
 
   # Set VNC security
   gosu deconz tigervncserver -SecurityTypes VncAuth,TLSVnc "$DECONZ_VNC_DISPLAY"

--- a/docker/root/start.sh
+++ b/docker/root/start.sh
@@ -93,7 +93,7 @@ if [ "$DECONZ_VNC_MODE" != 0 ]; then
   chown deconz:deconz /opt/deCONZ/vnc/passwd
 
   # Cleanup previous VNC session data
-  gosu deconz tigervncserver -kill "$DECONZ_VNC_DISPLAY"
+  gosu deconz tigervncserver -kill ':*'
   gosu deconz tigervncserver -list ':*' -cleanstale
   for lock in "/tmp/.X${DECONZ_VNC_DISPLAY#:}-lock" "/tmp/.X11-unix/X${DECONZ_VNC_DISPLAY#:}"; do
     [ -e "$lock" ] || continue


### PR DESCRIPTION
Thanks @MDXDave we had a hint that old lock files in the `/tmp` folder could prevent VNC from starting.

This PR should handle these problems (first approach was started in #104) and some more:
1. The used `kill` will only work for the configured port/display. If the configured port is changed from one start to another this might not work as intended.
2. `tigervncserver` also has an option for cleaning up lock files. Here you have to use `-cleanstale` at the `-list` command.
3. If there are still lock files which will prevent `tigervncserver` from starting VNC with a given display they will be logged and deleted. (`/tmp/.X42-lock` and `/tmp/.X11-unix/X42` with 42 being replaced by the display number)