### PR TITLE
Fixed incorrect command

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ To disable the login shell over serial and enable the serial port hardware:
 To swap Bluetooth to /dev/S0 (moving RaspBee to /dev/ttyAMA0), run the following command and then reboot:
 
 ```bash
-`echo 'dtoverlay=pi3-miniuart-bt' | sudo tee -a /boot/config.txt`
+echo 'dtoverlay=pi3-miniuart-bt' | sudo tee -a /boot/config.txt
 ```
 
 After running the above command and rebooting, RaspBee should be available at /dev/ttyAMA0.


### PR DESCRIPTION
When copying the command it fails with `command not found: dtoverlay=pi3-miniuart-bt` because of the two ` characters.