### PR TITLE
Disable provenence per docker/buildx#1513

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,6 +76,7 @@ jobs:
             VERSION=${{ steps.version.outputs.prop }}
             CHANNEL=${{ steps.channel.outputs.prop }}
           push: ${{ github.event_name != 'pull_request' }}
+          provenance: false
           tags: |
             deconzcommunity/deconz:latest
             deconzcommunity/deconz:${{ steps.version.outputs.prop }}


### PR DESCRIPTION
Workaround to opt-out of unsupported manifest until it's supported. Fix is from: https://github.com/docker/buildx/issues/1509#issuecomment-1378538197
[docker/buildx#1513 (comment)](https://github.com/docker/buildx/issues/1513#issuecomment-1398340039) 
Watchtower autoupdater should work again: https://github.com/containrrr/watchtower/discussions/1529