### PR TITLE
Fix OpenSSL3 crypto lib load of rest plugin

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -64,6 +64,10 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+# Fix for OpenSSL 3 crypto library linkage
+# (pairing w/ install code will not work otherwise and no errors regarding load library failures are logged)
+RUN cd /usr/lib/x86_64-linux-gnu && ln -s libcrypto.so.3 libcrypto.so
+
 # Workaround required on amd64 to address issue #292
 RUN if [ "${TARGETPLATFORM}" = "linux/amd64" ] ; then \
     apt-get update && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -64,9 +64,10 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Fix for OpenSSL 3 crypto library linkage
+# Fix for OpenSSL 3 crypto library linkage on linux/amd64 (status of other platforms unknown)
 # (pairing w/ install code will not work otherwise and no errors regarding load library failures are logged)
-RUN cd /usr/lib/x86_64-linux-gnu && ln -s libcrypto.so.3 libcrypto.so
+RUN if [ "${TARGETPLATFORM}" = "linux/amd64" ] ; then \
+    cd /usr/lib/x86_64-linux-gnu && ln -s libcrypto.so.3 libcrypto.so ; fi
 
 # Workaround required on amd64 to address issue #292
 RUN if [ "${TARGETPLATFORM}" = "linux/amd64" ] ; then \


### PR DESCRIPTION
To deconz-rest-plugin was added the feature to use install codes for pairing (e.g. used by Bosch Smart Home devices).

The docker for amd64 uses the Ubuntu deb package.
This seems to be linked against `libcrypto.so`, whereas Debian docker base provides only `libcrypto.so.3` library link.

Unfortunately the code does not log any failure on library loading.
After identification and test the problem was resolved by adding the required symlink `libcrypto.so -> libcrypto.so.3` to the Docker container.

After that joining devices that require install codes works like a charm.

Method that adds install code support: `RestDevices::putDeviceInstallCode`
(https://github.com/dresden-elektronik/deconz-rest-plugin/blob/master/rest_devices.cpp#L1029)

Utility function that uses OpenSSL 3 crypto library w/o failure logging of missing library: `CRYPTO_GetMmoHashFromInstallCode`
(https://github.com/dresden-elektronik/deconz-rest-plugin/blob/master/crypto/mmohash.cpp#L99)