### PR TITLE
Fix: Add privileged option to make it working

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ sudo usermod -a -G dialout $USER
 docker run -d \
     --name=deconz \
     --restart=always \
+    --privileged \
     -p 80:80 \
     -p 443:443 \
     -v /etc/localtime:/etc/localtime:ro \

--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ sudo usermod -a -G dialout $USER
 docker run -d \
     --name=deconz \
     --restart=always \
-    --privileged \
     -p 80:80 \
     -p 443:443 \
     -v /etc/localtime:/etc/localtime:ro \
@@ -80,6 +79,7 @@ docker run -d \
 | `--name=deconz`                       | Names the container "deconz".                                                                                                                                                                                                                                                                                                       |
 | `--net=host`                          | Uses host networking mode for proper uPNP functionality; by default, the web UIs and REST API listen on port 80 and the websockets service listens on port 443. If these ports conflict with other services on your host, you can change them through the environment variables DECONZ_WEB_PORT and DECONZ_WS_PORT described below. |
 | `--restart=always`                    | Start the container when Docker starts (i.e. on boot/reboot).                                                                                                                                                                                                                                                                       |
+| `--privileged`                        | Optionnal. Give privilege to the container. It can be required if the container is unable to use the device /dev/usbXXX and the logs show errors like `Unknown device "/dev/ttyUSB0": No such device`                                                                                                                                                                                                                                                                      |
 | `-v /etc/localtime:/etc/localtime:ro` | Ensure the container has the correct local time (alternatively, use the TZ environment variable, see below).                                                                                                                                                                                                                        |
 | `-v /opt/deconz:/opt/deCONZ`          | Bind mount /opt/deconz (or the directory of your choice) into the container for persistent storage.                                                                                                                                                                                                                                 |
 | `--device=/dev/ttyUSB0`               | Pass the serial device at ttyUSB0 into the container for use by deCONZ (you may need to investigate which device name is assigned to your device depending on if you are also using other usb serial devices; by default ConBee = /dev/ttyUSB0, Conbee II = /dev/ttyACM0, RaspBee = /dev/ttyAMA0 or /dev/ttyS0).                    |


### PR DESCRIPTION
I just bought a conBee III and after testing many different combinaison of option, I figured that the container was not able to connect to the device /dev/ttyUSB0.

I get the error with command `docker logs deconz`
`Unknown device "/dev/ttyUSB0": No such device`

Adding the option --privileged solved me this issue. Here is my command:
```bash
docker run -d \
    --name=deconz \
    --privileged \
    --restart=always \
    -p 8080:80 \
    -p 8443:443 \
    -v /etc/localtime:/etc/localtime:ro \
    -v /opt/deconz:/opt/deCONZ \
    -e DECONZ_BAUDRATE=115200 \
    -e DECONZ_DEVICE=/dev/ttyUSB0 \
    deconzcommunity/deconz
```