### PR TITLE
Add notes for RaspBee II users with correct DECONZ_BAUDRATE speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ If you're using a ConBee 3 stick, you need to set the following environment vari
 DECONZ_BAUDRATE=115200
 ```
 
+## Notes for RaspBeeII users
+
+If you're using a RaspBee II device, you need to set the following environment variable for deCONZ to pick be able to communicate with the stick:
+
+```
+DECONZ_BAUDRATE=38400
+```
+
 ## Notes for Synology users
 
 We've had numerous reports of issues when deCONZ is run as an unprivileged user, which is the default behaviour. Because of this, it is highly recommended that you run deCONZ as root. To do so, set the following two environment variables:


### PR DESCRIPTION
After the image _deconzcommunity/deconz:2.23.02_, I was never able to use the RaspbeeII until I explicitly configured the  environment variable DECONZ_BAUDRATE to 38400. Now the device is not only detected, as it was before too, but it can also be used properly. Therefore, I have considered to include this notes to the readme.