### PR TITLE
Replace gosu with setpriv

### DIFF
--- a/.github/workflows/gosu-runtime.yml
+++ b/.github/workflows/gosu-runtime.yml
@@ -1,0 +1,142 @@
+---
+name: gosu runtime smoke
+
+on:
+  pull_request:
+    paths:
+      - 'docker/**'
+      - 'version.json'
+      - '.github/workflows/gosu-runtime.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: gosu-runtime-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  runtime:
+    name: ${{ matrix.platform }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
+          - linux/arm/v7
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Read image version
+        id: version
+        run: |
+          set -euo pipefail
+          printf 'version=%s\n' "$(python3 -c 'import json; print(json.load(open("version.json"))["version"])')" >> "$GITHUB_OUTPUT"
+          printf 'channel=%s\n' "$(python3 -c 'import json; print(json.load(open("version.json"))["channel"])')" >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build local image
+        env:
+          PLATFORM: ${{ matrix.platform }}
+          VERSION: ${{ steps.version.outputs.version }}
+          CHANNEL: ${{ steps.version.outputs.channel }}
+        run: |
+          set -euo pipefail
+          platform_tag="${PLATFORM//\//-}"
+          docker buildx build \
+            --platform "$PLATFORM" \
+            --build-arg "VERSION=$VERSION" \
+            --build-arg "CHANNEL=$CHANNEL" \
+            --load \
+            --tag "deconz-gosu-runtime:$platform_tag" \
+            --file docker/Dockerfile \
+            docker
+
+      - name: Smoke runtime identity
+        env:
+          PLATFORM: ${{ matrix.platform }}
+        run: |
+          set -Eeuo pipefail
+          platform_tag="${PLATFORM//\//-}"
+          image="deconz-gosu-runtime:$platform_tag"
+
+          run_case() (
+            set -Eeuo pipefail
+            name="$1"
+            non_root="$2"
+            expected_uid="$3"
+            expected_gid="$4"
+            suffix="${platform_tag}-${name}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+            container="gosu-runtime-${suffix}"
+            volume="gosu-runtime-data-${suffix}"
+
+            cleanup() {
+              docker logs "$container" || true
+              docker inspect "$container" || true
+              docker rm -f "$container" || true
+              docker volume rm -f "$volume" || true
+            }
+            trap cleanup EXIT
+
+            docker volume create "$volume" >/dev/null
+            docker run -d --name "$container" \
+              --volume "$volume:/opt/deCONZ" \
+              --publish 127.0.0.1::80 \
+              --env "NON_ROOT=$non_root" \
+              --env DECONZ_DEVICE=0 \
+              --env DECONZ_VNC_MODE=0 \
+              "$image" >/dev/null
+
+            deadline=$((SECONDS + 60))
+            until docker exec "$container" curl -fsS http://127.0.0.1:80/ >/dev/null 2>&1; do
+              if ! docker inspect --format '{{.State.Running}}' "$container" | grep -qx true; then
+                echo "Container exited before HTTP became ready" >&2
+                return 1
+              fi
+              if (( SECONDS >= deadline )); then
+                echo "Timed out waiting for HTTP readiness" >&2
+                return 1
+              fi
+              sleep 2
+            done
+
+            docker exec "$container" awk \
+              -v expected_uid="$expected_uid" \
+              -v expected_gid="$expected_gid" '
+                $1 == "Uid:" {
+                  uid_found = 1
+                  if (NF != 5) failed = 1
+                  for (i = 2; i <= 5; i++) if ($i != expected_uid) failed = 1
+                }
+                $1 == "Gid:" {
+                  gid_found = 1
+                  if (NF != 5) failed = 1
+                  for (i = 2; i <= 5; i++) if ($i != expected_gid) failed = 1
+                }
+                END { exit !(uid_found && gid_found) || failed }
+              ' /proc/1/status
+            if [ "$non_root" = 0 ]; then
+              docker exec "$container" awk '
+                $1 == "CapInh:" { inh_found = 1; if ($2 != "0000000000000000") failed = 1 }
+                $1 == "CapPrm:" { prm_found = 1; if ($2 != "0000000000000400") failed = 1 }
+                $1 == "CapEff:" { eff_found = 1; if ($2 != "0000000000000400") failed = 1 }
+                END { exit !(inh_found && prm_found && eff_found) || failed }
+              ' /proc/1/status
+            fi
+            docker exec "$container" sh -ec '
+              set -- $(tr "\\000" " " </proc/1/cmdline)
+              test "$1" = /usr/bin/deCONZ
+            '
+          )
+
+          run_case default 0 1000 1000
+          run_case root-fallback 1 0 0

--- a/.github/workflows/gosu-runtime.yml
+++ b/.github/workflows/gosu-runtime.yml
@@ -81,7 +81,7 @@ jobs:
 
             cleanup() {
               docker logs "$container" || true
-              docker inspect "$container" || true
+              docker inspect --format 'state={{.State.Status}} exit={{.State.ExitCode}} pid={{.State.Pid}} health={{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$container" || true
               docker rm -f "$container" || true
               docker volume rm -f "$volume" || true
             }
@@ -109,6 +109,12 @@ jobs:
               sleep 2
             done
 
+            docker exec "$container" sh -ec '
+              awk "/^(Uid|Gid|CapInh|CapPrm|CapEff):/ { print }" /proc/1/status
+              printf "Cmdline: "
+              tr "\\000" " " </proc/1/cmdline
+              printf "\n"
+            '
             docker exec "$container" awk \
               -v expected_uid="$expected_uid" \
               -v expected_gid="$expected_gid" '

--- a/.github/workflows/gosu-runtime.yml
+++ b/.github/workflows/gosu-runtime.yml
@@ -139,8 +139,16 @@ jobs:
               ' /proc/1/status
             fi
             docker exec "$container" sh -ec '
-              set -- $(tr "\\000" " " </proc/1/cmdline)
-              test "$1" = /usr/bin/deCONZ
+              tr "\\000" "\n" </proc/1/cmdline | awk "
+                NR == 1 { argv0 = \$0 }
+                NR == 2 { argv1 = \$0 }
+                END {
+                  exit !(
+                    argv0 == \"/usr/bin/deCONZ\" ||
+                    (argv0 ~ \"^/usr/bin/qemu-[^/]+\$\" && argv1 == \"/usr/bin/deCONZ\")
+                  )
+                }
+              "
             '
           )
 

--- a/.github/workflows/gosu-runtime.yml
+++ b/.github/workflows/gosu-runtime.yml
@@ -139,16 +139,12 @@ jobs:
               ' /proc/1/status
             fi
             docker exec "$container" sh -ec '
-              tr "\\000" "\n" </proc/1/cmdline | awk "
-                NR == 1 { argv0 = \$0 }
-                NR == 2 { argv1 = \$0 }
-                END {
-                  exit !(
-                    argv0 == \"/usr/bin/deCONZ\" ||
-                    (argv0 ~ \"^/usr/bin/qemu-[^/]+\$\" && argv1 == \"/usr/bin/deCONZ\")
-                  )
-                }
-              "
+              set -- $(tr "\\000" " " </proc/1/cmdline)
+              case "$1" in
+                /usr/bin/deCONZ) ;;
+                /usr/bin/qemu-*) test "$2" = /usr/bin/deCONZ ;;
+                *) exit 1 ;;
+              esac
             '
           )
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -41,7 +41,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
 # Install deCONZ dependencies
 RUN apt-get update && \
     apt-get install -y \
-        gosu \
+        util-linux \
         curl \
         kmod \
         udev \

--- a/docker/root/start.sh
+++ b/docker/root/start.sh
@@ -4,6 +4,13 @@ if [ "$DECONZ_START_VERBOSE" = 1 ]; then
   set -x
 fi
 
+as_deconz() {
+  if [ "$NON_ROOT" = 0 ]; then
+    setpriv --reuid=deconz --regid=deconz --init-groups --inh-caps=-all -- "$@"
+  else
+    "$@"
+  fi
+}
 
 echo "[deconzcommunity/deconz] Starting deCONZ..."
 echo "[deconzcommunity/deconz] Current deCONZ version: $DECONZ_VERSION"
@@ -25,12 +32,6 @@ DECONZ_OPTS="--auto-connect=1 \
         --http-port=$DECONZ_WEB_PORT \
         --https-port=$DECONZ_WEBS_PORT \
         --ws-port=$DECONZ_WS_PORT"
-
-if [ "$NON_ROOT" = 0 ]; then 
-  GOSU="gosu deconz"
-else
-  GOSU=""
-fi
 
 if [ "$DECONZ_BAUDRATE" != 0 ]; then
   DECONZ_OPTS="$DECONZ_OPTS --baudrate=$DECONZ_BAUDRATE"
@@ -121,8 +122,8 @@ if [ "$DECONZ_VNC_MODE" != 0 ]; then
   fi
 
   # Cleanup previous VNC session data
-  $GOSU tigervncserver -kill ':*'
-  $GOSU tigervncserver -list ':*' -cleanstale
+  as_deconz tigervncserver -kill ':*'
+  as_deconz tigervncserver -list ':*' -cleanstale
   for lock in "/tmp/.X${DECONZ_VNC_DISPLAY#:}-lock" "/tmp/.X11-unix/X${DECONZ_VNC_DISPLAY#:}"; do
     [ -e "$lock" ] || continue
     echo "[deconzcommunity/deconz] WARN - VNC-lock found. Deleting: $lock"
@@ -130,7 +131,7 @@ if [ "$DECONZ_VNC_MODE" != 0 ]; then
   done
 
   # Set VNC security
-  $GOSU tigervncserver -SecurityTypes "$SECURITYTYPES" -PasswordFile $DECONZ_APPDATA_DIR/vnc/passwd "$DECONZ_VNC_DISPLAY"
+  as_deconz tigervncserver -SecurityTypes "$SECURITYTYPES" -PasswordFile $DECONZ_APPDATA_DIR/vnc/passwd "$DECONZ_VNC_DISPLAY"
 
   # Export VNC display variable
   export DISPLAY=$DECONZ_VNC_DISPLAY
@@ -159,7 +160,7 @@ if [ "$DECONZ_VNC_MODE" != 0 ]; then
     chown deconz:deconz $NOVNC_CERT
 
     #Start noVNC
-    $GOSU websockify -D --web=/usr/share/novnc/ --cert="$NOVNC_CERT" $DECONZ_NOVNC_PORT localhost:$DECONZ_VNC_PORT
+    as_deconz websockify -D --web=/usr/share/novnc/ --cert="$NOVNC_CERT" $DECONZ_NOVNC_PORT localhost:$DECONZ_VNC_PORT
     echo "[deconzcommunity/deconz] NOVNC port: $DECONZ_NOVNC_PORT"
   fi
 
@@ -181,4 +182,8 @@ ln -sfT $DECONZ_APPDATA_DIR/otau /home/deconz/otau
 chown deconz:deconz /home/deconz/otau
 chown deconz:deconz $DECONZ_APPDATA_DIR -R
 
-exec $GOSU /usr/bin/deCONZ $DECONZ_OPTS
+if [ "$NON_ROOT" = 0 ]; then
+  exec setpriv --reuid=deconz --regid=deconz --init-groups --inh-caps=-all -- /usr/bin/deCONZ $DECONZ_OPTS
+else
+  exec /usr/bin/deCONZ $DECONZ_OPTS
+fi


### PR DESCRIPTION
## Summary
- replace gosu with util-linux setpriv for deCONZ privilege drop
- preserve root fallback and deCONZ file-capability handoff
- add multi-architecture runtime identity and capability smoke coverage

## Validation
- `git diff --check`
- `sh -n docker/root/start.sh`
- Ruby YAML parse
- independent diff review
- Docker daemon unavailable locally; runtime matrix runs in GitHub Actions